### PR TITLE
Add README with server and API key instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Europe Trip Planner Webpage
+
+This repository contains `europe_trip.html`, an interactive itinerary planner that uses the Google Gemini API for optional AI features.
+
+## Serving the Page
+Use a local web server so the scripts can load correctly. Two easy options are:
+
+1. **npx serve** (requires Node.js)
+   ```bash
+   npx serve .
+   ```
+   Then open `http://localhost:3000/europe_trip.html` in your browser (the port shown in the command output may differ).
+
+2. **VS Code Live Server**
+   Install the "Live Server" extension, right‑click `europe_trip.html`, and choose **Open with Live Server**.
+
+## Supplying the Gemini API Key
+`europe_trip.html` expects a Gemini API key for the AI-powered features. Do **not** commit your key to version control. One approach is:
+
+1. Create a `config.js` file **outside of version control** (add it to `.gitignore` if necessary).
+2. Inside `config.js`, define:
+   ```js
+   const geminiApiKey = 'YOUR_GEMINI_API_KEY';
+   ```
+3. Include `config.js` in `europe_trip.html` with a `<script src="config.js"></script>` tag before the script that calls the API.
+4. Modify the `callGemini` function in the HTML to reference `geminiApiKey` instead of a hard‑coded string.
+
+Alternatively, you could store the key in an environment variable and have a small server script inject it or prompt for it at runtime. The key should never be committed to the repository.


### PR DESCRIPTION
## Summary
- document how to serve `europe_trip.html`
- explain how to keep the Gemini API key out of the repository

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a688b5090832c805ec223a7d8d0c5