### PR TITLE
Replace hardcoded API key

### DIFF
--- a/europe_trip.html
+++ b/europe_trip.html
@@ -297,7 +297,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     
     async function callGemini(prompt) {
-        const apiKey = "AIzaSyAxgLxSLsnCqFaIE_FTtv2HJuKgTJn5G-Q"; 
+        const apiKey = ""; // Supply via env variable or user input before hosting
         const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`;
         const payload = { contents: [{ role: "user", parts: [{ text: prompt }] }] };
 


### PR DESCRIPTION
## Summary
- replace hardcoded API key with empty placeholder
- note that the key should come from env var or user input before hosting

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684a688a1e00832cb5629a9cdf1cb933