### PR TITLE
Add server for env-based API key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+config.js

--- a/README.md
+++ b/README.md
@@ -26,3 +26,16 @@ Use a local web server so the scripts can load correctly. Two easy options are:
 4. Modify the `callGemini` function in the HTML to reference `geminiApiKey` instead of a hard‑coded string.
 
 Alternatively, you could store the key in an environment variable and have a small server script inject it or prompt for it at runtime. The key should never be committed to the repository.
+
+### Using `server.js` and an Environment Variable
+
+1. Set the environment variable `GEMINI_API_KEY` with your key:
+   ```bash
+   export GEMINI_API_KEY=YOUR_GEMINI_API_KEY
+   ```
+2. Start the provided server:
+   ```bash
+   node server.js
+   ```
+   This serves `europe_trip.html` at `http://localhost:3000` and exposes the key via `config.js`.
+3. Open the page in your browser and the AI features will use the key automatically.

--- a/europe_trip.html
+++ b/europe_trip.html
@@ -184,6 +184,7 @@
         </footer>
     </div>
 
+    <script src="config.js"></script>
 <script>
 const AppData = {
     itineraries: [
@@ -297,7 +298,11 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     
     async function callGemini(prompt) {
-        const apiKey = ""; // Supply via env variable or user input before hosting
+        const apiKey = typeof geminiApiKey !== 'undefined' ? geminiApiKey : "";
+        if (!apiKey) {
+            console.error('Gemini API key not provided.');
+            return "Gemini API key not configured.";
+        }
         const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`;
         const payload = { contents: [{ role: "user", parts: [{ text: prompt }] }] };
 

--- a/server.js
+++ b/server.js
@@ -1,0 +1,50 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const port = process.env.PORT || 3000;
+const geminiApiKey = process.env.GEMINI_API_KEY || '';
+
+const mimeTypes = {
+  '.html': 'text/html',
+  '.js': 'text/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon'
+};
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/config.js') {
+    res.writeHead(200, { 'Content-Type': 'application/javascript' });
+    res.end(`const geminiApiKey = '${geminiApiKey}';`);
+    return;
+  }
+
+  let filePath = '.' + req.url;
+  if (filePath === './') filePath = './europe_trip.html';
+
+  const ext = path.extname(filePath).toLowerCase();
+  const contentType = mimeTypes[ext] || 'application/octet-stream';
+
+  fs.readFile(filePath, (err, content) => {
+    if (err) {
+      if (err.code === 'ENOENT') {
+        res.writeHead(404, { 'Content-Type': 'text/plain' });
+        res.end('404 Not Found');
+      } else {
+        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        res.end('Server Error');
+      }
+    } else {
+      res.writeHead(200, { 'Content-Type': contentType });
+      res.end(content, 'utf-8');
+    }
+  });
+});
+
+server.listen(port, () => {
+  console.log(`Server running at http://localhost:${port}/`);
+});


### PR DESCRIPTION
## Summary
- add `server.js` for injecting `GEMINI_API_KEY`
- load `config.js` in `europe_trip.html`
- read `geminiApiKey` and handle missing key
- document env var setup in README
- ignore `config.js` and `node_modules`

## Testing
- `node --check server.js`
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684a695d1a30832caf2423d27a1e598e